### PR TITLE
Fix event_executions_status_check constraint for detection_failed/handler_failed

### DIFF
--- a/src/plugins/observability/model/DATA_MODEL.md
+++ b/src/plugins/observability/model/DATA_MODEL.md
@@ -151,7 +151,7 @@ event_name            TEXT           -- e.g., 'move.pickup.successful'
 detected              BOOLEAN        -- Was event triggered?
 detection_duration_ms INTEGER        -- Time for detector function
 detection_error       TEXT           -- Error during detection
-status               TEXT           -- 'detecting', 'not_detected', 'handling', 'completed', 'failed'
+status               TEXT           -- 'detecting', 'not_detected', 'handling', 'completed', 'failed', 'detection_failed', 'handler_failed'
 
 -- Handler phase (if detected)
 handler_duration_ms   INTEGER        -- Time for handler function

--- a/src/plugins/observability/model/migrations/002_fix_event_executions_status_constraint_down.sql
+++ b/src/plugins/observability/model/migrations/002_fix_event_executions_status_constraint_down.sql
@@ -1,0 +1,75 @@
+-- Migration: Revert event_executions status check constraint
+-- Version: 002 (DOWN)
+-- Description: Reverts the event_executions status check constraint to the original set of allowed values.
+--
+-- Prerequisites:
+-- 1. Connect to event_detector_observability database before running this script
+-- Usage: psql -h your-rds-endpoint -U observability_admin -d event_detector_observability -f 002_fix_event_executions_status_constraint_down.sql
+--
+-- WARNING: Any rows with status 'detection_failed' or 'handler_failed' must be updated before running this!
+
+-- Verify we're connected to the correct database
+DO $$
+BEGIN
+    IF current_database() != 'event_detector_observability' THEN
+        RAISE EXCEPTION 'This migration must be run on the event_detector_observability database. Current database: %', current_database();
+    END IF;
+    RAISE NOTICE 'Running migration 002 (DOWN) on database: %', current_database();
+END $$;
+
+-- Check for rows that would violate the reverted constraint
+DO $$
+DECLARE
+    row_count INTEGER;
+BEGIN
+    SELECT COUNT(*) INTO row_count
+    FROM event_executions
+    WHERE status IN ('detection_failed', 'handler_failed');
+
+    IF row_count > 0 THEN
+        RAISE WARNING 'Found % rows with status detection_failed or handler_failed. Updating to failed before reverting constraint.', row_count;
+    END IF;
+END $$;
+
+-- Migrate any rows with the new statuses back to 'failed' so they don't violate the old constraint
+UPDATE event_executions SET status = 'failed' WHERE status IN ('detection_failed', 'handler_failed');
+
+-- Drop the updated constraint
+ALTER TABLE event_executions
+DROP CONSTRAINT IF EXISTS event_executions_status_check;
+
+-- Re-add the original constraint
+ALTER TABLE event_executions
+ADD CONSTRAINT event_executions_status_check
+CHECK (status IN ('detecting', 'not_detected', 'handling', 'completed', 'failed'));
+
+-- Verify the changes
+DO $$
+DECLARE
+    constraint_exists BOOLEAN;
+BEGIN
+    SELECT EXISTS (
+        SELECT 1 FROM information_schema.check_constraints
+        WHERE constraint_name = 'event_executions_status_check'
+        AND constraint_schema = 'public'
+    ) INTO constraint_exists;
+
+    IF constraint_exists THEN
+        RAISE NOTICE 'SUCCESS: Migration 002 (DOWN) completed successfully';
+        RAISE NOTICE 'Reverted event_executions_status_check to original values: detecting, not_detected, handling, completed, failed';
+    ELSE
+        RAISE EXCEPTION 'Migration failed - event_executions_status_check constraint not found after revert';
+    END IF;
+END $$;
+
+-- Final message
+DO $$
+BEGIN
+    RAISE NOTICE '==========================================';
+    RAISE NOTICE 'Migration 002 (DOWN) completed successfully!';
+    RAISE NOTICE '==========================================';
+    RAISE NOTICE 'Reverted: event_executions_status_check constraint';
+    RAISE NOTICE 'Removed values: detection_failed, handler_failed';
+    RAISE NOTICE 'To re-apply: Run 002_fix_event_executions_status_constraint_up.sql';
+    RAISE NOTICE '==========================================';
+END $$;

--- a/src/plugins/observability/model/migrations/002_fix_event_executions_status_constraint_up.sql
+++ b/src/plugins/observability/model/migrations/002_fix_event_executions_status_constraint_up.sql
@@ -1,0 +1,58 @@
+-- Migration: Fix event_executions status check constraint
+-- Version: 002
+-- Description: Adds 'detection_failed' and 'handler_failed' to the event_executions status check constraint.
+--              The ObservabilityPlugin writes these statuses when detector or handler errors occur, but the
+--              existing constraint rejects them, causing a cascading failure loop (500 on every event).
+--
+-- Prerequisites:
+-- 1. Connect to event_detector_observability database before running this script
+-- Usage: psql -h your-rds-endpoint -U observability_admin -d event_detector_observability -f 002_fix_event_executions_status_constraint_up.sql
+
+-- Verify we're connected to the correct database
+DO $$
+BEGIN
+    IF current_database() != 'event_detector_observability' THEN
+        RAISE EXCEPTION 'This migration must be run on the event_detector_observability database. Current database: %', current_database();
+    END IF;
+    RAISE NOTICE 'Running migration 002 (UP) on database: %', current_database();
+END $$;
+
+-- Drop the existing check constraint
+ALTER TABLE event_executions
+DROP CONSTRAINT IF EXISTS event_executions_status_check;
+
+-- Re-add with the full set of allowed status values
+ALTER TABLE event_executions
+ADD CONSTRAINT event_executions_status_check
+CHECK (status IN ('detecting', 'not_detected', 'handling', 'completed', 'failed', 'detection_failed', 'handler_failed'));
+
+-- Verify the changes
+DO $$
+DECLARE
+    constraint_exists BOOLEAN;
+BEGIN
+    SELECT EXISTS (
+        SELECT 1 FROM information_schema.check_constraints
+        WHERE constraint_name = 'event_executions_status_check'
+        AND constraint_schema = 'public'
+    ) INTO constraint_exists;
+
+    IF constraint_exists THEN
+        RAISE NOTICE 'SUCCESS: Migration 002 completed successfully';
+        RAISE NOTICE 'Updated event_executions_status_check to allow: detecting, not_detected, handling, completed, failed, detection_failed, handler_failed';
+    ELSE
+        RAISE EXCEPTION 'Migration failed - event_executions_status_check constraint not found after update';
+    END IF;
+END $$;
+
+-- Final message
+DO $$
+BEGIN
+    RAISE NOTICE '==========================================';
+    RAISE NOTICE 'Migration 002 (UP) completed successfully!';
+    RAISE NOTICE '==========================================';
+    RAISE NOTICE 'Updated: event_executions_status_check constraint';
+    RAISE NOTICE 'Added values: detection_failed, handler_failed';
+    RAISE NOTICE 'To undo: Run 002_fix_event_executions_status_constraint_down.sql';
+    RAISE NOTICE '==========================================';
+END $$;

--- a/src/plugins/observability/model/migrations/README.md
+++ b/src/plugins/observability/model/migrations/README.md
@@ -102,6 +102,10 @@ FROM job_chain
 ORDER BY created_at, depth;
 ```
 
+### 002 - Fix event_executions status check constraint
+- **Up**: `002_fix_event_executions_status_constraint_up.sql` - Adds `detection_failed` and `handler_failed` to the allowed status values in the `event_executions_status_check` constraint
+- **Down**: `002_fix_event_executions_status_constraint_down.sql` - Reverts the constraint to the original set of allowed values (migrates any affected rows to `failed` first)
+
 ### Creating New Migrations
 
 When creating new migration files:

--- a/src/plugins/observability/model/schema.sql
+++ b/src/plugins/observability/model/schema.sql
@@ -124,7 +124,7 @@ CREATE TABLE event_executions (
     jobs_failed INTEGER DEFAULT 0,
 
     -- Status tracking
-    status TEXT NOT NULL DEFAULT 'detecting' CHECK (status IN ('detecting', 'not_detected', 'handling', 'completed', 'failed'))
+    status TEXT NOT NULL DEFAULT 'detecting' CHECK (status IN ('detecting', 'not_detected', 'handling', 'completed', 'failed', 'detection_failed', 'handler_failed'))
 );
 
 -- Job execution - each async job run for detected events


### PR DESCRIPTION
## Summary

- **Fixes a cascading failure loop** in the event-handlers test environment: when a detector throws, the ObservabilityPlugin tries to insert `status: 'detection_failed'` (or `'handler_failed'`), which violates the `event_executions_status_check` constraint, causing a 500 on every subsequent event.
- Adds migration 002 that drops and re-adds the `event_executions_status_check` constraint with the full set of status values: `detecting`, `not_detected`, `handling`, `completed`, `failed`, `detection_failed`, `handler_failed`.
- Updates `schema.sql` and `DATA_MODEL.md` so fresh installs get the correct constraint from the start.

This is a **schema-only fix** to align the database constraint with the `@hopdrive/hasura-event-detector` package's ObservabilityPlugin — no application code changes are needed.

## Migration details

| File | Action |
|------|--------|
| `002_fix_event_executions_status_constraint_up.sql` | Drops old constraint, adds new one with `detection_failed` and `handler_failed` |
| `002_fix_event_executions_status_constraint_down.sql` | Migrates affected rows to `failed`, then reverts to original constraint |

Run against the `event_detector_observability` database:
```bash
psql -h <endpoint> -U observability_admin -d event_detector_observability -f 002_fix_event_executions_status_constraint_up.sql
```

## Test plan

- [ ] Run migration UP against test environment `event_detector_observability` database
- [ ] Verify constraint allows `detection_failed` and `handler_failed` inserts
- [ ] Trigger a detector error and confirm the failure is logged without a 500 loop
- [ ] Run migration DOWN and verify rollback works cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)