### PR TITLE
chore: pin local dev ports (8851) + monitoring local domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1382,3 +1382,18 @@ This project is licensed under the ISC License - see the [LICENSE](LICENSE) file
 ---
 
 **Built with ❤️ by the HopDrive team**
+
+## Local development
+
+Dev ports are pinned org-wide so any combination of HopDrive sites can run at the same time.
+
+| Layer | Port |
+|---|---|
+| Netlify dev (functions + proxy) | **8851** |
+
+Start the site with `ntl dev`, then open either:
+
+- http://localhost:8851
+- http://monitoring.local.hopdrive.io:8851 — `*.local.hopdrive.io` resolves to `127.0.0.1` via public DNS; works on any machine with no `/etc/hosts` changes.
+
+Always use the 8851 URLs so Netlify functions and redirects behave like production.

--- a/README.md
+++ b/README.md
@@ -1396,4 +1396,10 @@ Start the site with `ntl dev`, then open either:
 - http://localhost:8851
 - http://monitoring.local.hopdrive.io:8851 — `*.local.hopdrive.io` resolves to `127.0.0.1` via public DNS; works on any machine with no `/etc/hosts` changes.
 
+**Preferred — no ports at all:** with the org https proxy running (`hopdrive up`, from `@hopdrive/cli` v2), this site is simply:
+
+- https://monitoring.local.hopdrive.io
+
+Caddy terminates https with a locally-trusted cert and routes to this site's pinned port automatically; a site that isn't running just returns 502. This is the interim standard until the monorepo's `hop dev` lands.
+
 Always use the 8851 URLs so Netlify functions and redirects behave like production.

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,7 @@
 
 [dev]
   targetPort = 3000
+  port = 8851
 
 [build.environment]
   NODE_VERSION = "20"


### PR DESCRIPTION
## Org-wide local-dev port pinning

Every HopDrive site now owns a unique local port pair so any combination of sites runs concurrently (previously five repos claimed :8888 and four :8891). Scheme: apps 8801–09 · monorepo domain services 8811–39 (reserved) · integrations 8841–59 · internal tools 8861–69 · legacy portals 8871–79; xx73 never assigned (Vite default 5173 kept vacant as a canary).

**This repo: ntl `8851` / http://monitoring.local.hopdrive.io:8851** — `*.local.hopdrive.io → 127.0.0.1` is live in Cloudflare; zero machine setup.

Dev-only change. Zero production impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
